### PR TITLE
Tow 119 dao and service method to get all projects

### DIFF
--- a/townhall/myapi/dao.py
+++ b/townhall/myapi/dao.py
@@ -387,3 +387,7 @@ class ProjectDao:
             return project
         except Project.DoesNotExist:
             return None
+
+    @staticmethod
+    def get_project_all() -> typing.Optional[Project]:
+        return Project.objects.all()

--- a/townhall/myapi/dao.py
+++ b/townhall/myapi/dao.py
@@ -389,5 +389,5 @@ class ProjectDao:
             return None
 
     @staticmethod
-    def get_project_all() -> typing.Optional[Project]:
+    def get_project_all() -> QuerySet[Project]:
         return Project.objects.all()

--- a/townhall/myapi/services.py
+++ b/townhall/myapi/services.py
@@ -451,4 +451,4 @@ class ProjectServices:
 
     @staticmethod
     def get_all_projects() -> typing.List[Project]:
-        return project_dao.get_project_all()
+        return list(project_dao.get_project_all())

--- a/townhall/myapi/services.py
+++ b/townhall/myapi/services.py
@@ -448,3 +448,7 @@ class ProjectServices:
     @staticmethod
     def get_project(id: int) -> typing.Optional[Project]:
         return project_dao.get_project(id=id)
+
+    @staticmethod
+    def get_all_projects() -> typing.List[Project]:
+        return project_dao.get_project_all()

--- a/townhall/tests/service_tests/test_project_service.py
+++ b/townhall/tests/service_tests/test_project_service.py
@@ -18,6 +18,13 @@ class TestProjectModel(TestCase):
             description="Description1",
             start_date=timezone.make_aware(datetime(2024, 7, 20, 10, 0)),
             end_date=timezone.make_aware(datetime(2024, 7, 20, 20, 30)),
+        ),
+        townhall_models.Project.objects.create(
+            id=2,
+            title="Project2",
+            description="Description2",
+            start_date=timezone.make_aware(datetime(2024, 7, 20, 10, 0)),
+            end_date=timezone.make_aware(datetime(2024, 7, 20, 20, 30)),
         )
 
     def test_get_project(self):
@@ -28,5 +35,16 @@ class TestProjectModel(TestCase):
         assert project.end_date == timezone.make_aware(datetime(2024, 7, 20, 20, 30))
 
     def test_get_project_not_found(self):
-        project = townhall_services.ProjectServices.get_project(id=2)
+        project = townhall_services.ProjectServices.get_project(id=100)
         assert project is None
+
+    def test_get_all_projects(self):
+        projects = townhall_services.ProjectServices.get_all_projects()
+        assert len(projects) == 2
+        assert projects[0].title == "Project1"
+        assert projects[1].title == "Project2"
+
+    def test_get_all_projects_empty(self):
+        townhall_models.Project.objects.all().delete()
+        projects = townhall_services.ProjectServices.get_all_projects()
+        assert len(projects) == 0

--- a/townhall/tests/service_tests/test_project_service.py
+++ b/townhall/tests/service_tests/test_project_service.py
@@ -7,7 +7,7 @@ from django.utils import timezone
 # Project
 
 # Testing ALL tests "python manage.py test tests"
-# Testing ONLY project python manage.py tests.service_tests.test_project_services
+# Testing ONLY project python manage.py test tests.service_tests.test_project_service
 
 
 class TestProjectModel(TestCase):

--- a/townhall/tests/service_tests/test_project_service.py
+++ b/townhall/tests/service_tests/test_project_service.py
@@ -4,11 +4,6 @@ from myapi import services as townhall_services
 from datetime import datetime
 from django.utils import timezone
 
-# Project
-
-# Testing ALL tests "python manage.py test tests"
-# Testing ONLY project "python manage.py test tests.service_tests.test_project_service"
-
 
 class TestProjectModel(TestCase):
     def setUp(self):
@@ -18,7 +13,7 @@ class TestProjectModel(TestCase):
             description="Description1",
             start_date=timezone.make_aware(datetime(2024, 7, 20, 10, 0)),
             end_date=timezone.make_aware(datetime(2024, 7, 20, 20, 30)),
-        ),
+        )
         townhall_models.Project.objects.create(
             id=2,
             title="Project2",
@@ -29,22 +24,27 @@ class TestProjectModel(TestCase):
 
     def test_get_project(self):
         project = townhall_services.ProjectServices.get_project(id=1)
-        assert project.title == "Project1"
-        assert project.description == "Description1"
-        assert project.start_date == timezone.make_aware(datetime(2024, 7, 20, 10, 0))
-        assert project.end_date == timezone.make_aware(datetime(2024, 7, 20, 20, 30))
+        self.assertIsNotNone(project)
+        self.assertEqual(project.title, "Project1")
+        self.assertEqual(project.description, "Description1")
+        self.assertEqual(
+            project.start_date, timezone.make_aware(datetime(2024, 7, 20, 10, 0))
+        )
+        self.assertEqual(
+            project.end_date, timezone.make_aware(datetime(2024, 7, 20, 20, 30))
+        )
 
     def test_get_project_not_found(self):
         project = townhall_services.ProjectServices.get_project(id=100)
-        assert project is None
+        self.assertIsNone(project)
 
     def test_get_all_projects(self):
         projects = townhall_services.ProjectServices.get_all_projects()
-        assert len(projects) == 2
-        assert projects[0].title == "Project1"
-        assert projects[1].title == "Project2"
+        self.assertEqual(len(projects), 2)
+        self.assertEqual(projects[0].title, "Project1")
+        self.assertEqual(projects[1].title, "Project2")
 
     def test_get_all_projects_empty(self):
         townhall_models.Project.objects.all().delete()
         projects = townhall_services.ProjectServices.get_all_projects()
-        assert len(projects) == 0
+        self.assertEqual(len(projects), 0)

--- a/townhall/tests/service_tests/test_project_service.py
+++ b/townhall/tests/service_tests/test_project_service.py
@@ -4,6 +4,11 @@ from myapi import services as townhall_services
 from datetime import datetime
 from django.utils import timezone
 
+# Project
+
+# Testing ALL tests "python manage.py test tests"
+# Testing ONLY project python manage.py tests.service_tests.test_project_services
+
 
 class TestProjectModel(TestCase):
     def setUp(self):


### PR DESCRIPTION
## JIRA Ticket Link
[https://atriadev.atlassian.net/jira/software/projects/TOW/boards/1?selectedIssue=TOW-119&text=Project](url)

## Migrations Required?
NO :negative_squared_cross_mark:


## Summary (a few sentences describing what this PR is doing) 
Added get_project_all() in dao and service files

## Checks
-  [x] I have ran all the tests locally, and they all pass

## Learnings
Describe in 1-2 sentences what you learned from doing this task
- Learned about self.assertX instead of using default assert statements
- Learned about the default Manager in Django, Model.objects
