### PR TITLE
Tow 182 volunteer filter endpoints

### DIFF
--- a/townhall/myapi/dao.py
+++ b/townhall/myapi/dao.py
@@ -70,11 +70,10 @@ class VolunteerDao:
     def filter_all_volunteers(filtersDict) -> QuerySet[Volunteer]:
         return Volunteer.objects.filter(**filtersDict)
 
-    def get_all_opportunities_of_a_volunteer(
-        volunteer_id: int,
+    def get_all_filtered_opportunities_of_a_volunteer(
+        filters_dict,
     ) -> QuerySet[Opportunity]:
-        volunteer = Volunteer.objects.get(id=volunteer_id)
-        return volunteer.opportunities.all()
+        return Opportunity.objects.filter(**filters_dict)
 
     def add_volunteer_to_opportunity(volunteer_id: int, opportunity_id: int) -> None:
         opportunity = Opportunity.objects.get(id=opportunity_id)

--- a/townhall/myapi/dao.py
+++ b/townhall/myapi/dao.py
@@ -67,6 +67,9 @@ class VolunteerDao:
 
         volunteer.save()
 
+    def filter_all_volunteers(filtersDict) -> QuerySet[Volunteer]:
+        return Volunteer.objects.filter(**filtersDict)
+
     def get_all_opportunities_of_a_volunteer(
         volunteer_id: int,
     ) -> QuerySet[Opportunity]:

--- a/townhall/myapi/serializers.py
+++ b/townhall/myapi/serializers.py
@@ -55,13 +55,25 @@ class UpdateVolunteerSerializer(serializers.Serializer):
 
 
 class FilterVolunteerSerializer(serializers.Serializer):
+    should_filter = serializers.BooleanField(required=True)
     first_name = serializers.CharField(required=False)
     last_name = serializers.CharField(required=False)
     email = serializers.EmailField(required=False)
     gender = serializers.ChoiceField(
         choices=[("M", "Male"), ("F", "Female")], required=False
     )
-    is_active = serializers.BooleanField(required=False)
+    is_active = serializers.BooleanField(required=False, allow_null=True)
+
+    def validate(self, data):
+        if data.get("should_filter"):
+            if all(
+                data.get(field) is None
+                for field in ["first_name", "last_name", "email", "gender", "is_active"]
+            ):
+                raise serializers.ValidationError(
+                    {"should_filter": "This field is required."}
+                )
+        return data
 
 
 class ChangePasswordVolunteerSerializer(serializers.Serializer):

--- a/townhall/myapi/serializers.py
+++ b/townhall/myapi/serializers.py
@@ -54,6 +54,16 @@ class UpdateVolunteerSerializer(serializers.Serializer):
         return data
 
 
+class FilterVolunteerSerializer(serializers.Serializer):
+    first_name = serializers.CharField(required=False)
+    last_name = serializers.CharField(required=False)
+    email = serializers.EmailField(required=False)
+    gender = serializers.ChoiceField(
+        choices=[("M", "Male"), ("F", "Female")], required=False
+    )
+    is_active = serializers.BooleanField(required=False)
+
+
 class ChangePasswordVolunteerSerializer(serializers.Serializer):
     email = serializers.EmailField(required=True)
     curr_password = serializers.CharField(max_length=128, required=True)

--- a/townhall/myapi/serializers.py
+++ b/townhall/myapi/serializers.py
@@ -12,6 +12,16 @@ class OpportunitySerializer(serializers.ModelSerializer):
         fields = "__all__"
 
 
+class FilteredOpportunitySerializer(serializers.Serializer):
+    title = serializers.CharField(required=False)
+    starting_start_time = serializers.DateTimeField(required=False)
+    starting_end_time = serializers.DateTimeField(required=False)
+    ending_start_time = serializers.DateTimeField(required=False)
+    ending_end_time = serializers.DateTimeField(required=False)
+    location = serializers.CharField(required=False)
+    organization_id = serializers.IntegerField(required=False)
+
+
 class VolunteerSerializer(serializers.ModelSerializer):
 
     class Meta:

--- a/townhall/myapi/services.py
+++ b/townhall/myapi/services.py
@@ -20,6 +20,7 @@ from .dao import ProjectDao as project_dao
 
 from .types import CreateVolunteerData
 from .types import UpdateVolunteerData
+from .types import FilterVolunteerData
 from .types import ChangeVolunteerPasswordData
 
 from .types import CreateTaskData
@@ -83,6 +84,24 @@ class VolunteerServices:
             volunteer_dao.delete_volunteer(volunteer_id=id)
         except Volunteer.DoesNotExist:
             raise ValidationError(f"Volunteer with the given id: {id}, does not exist.")
+
+    def filter_all_volunteers(
+        filter_volunteer_data: FilterVolunteerData,
+    ) -> QuerySet[Volunteer]:
+        filters = {}
+
+        if filter_volunteer_data.first_name:
+            filters["first_name__icontains"] = filter_volunteer_data.first_name
+        if filter_volunteer_data.last_name:
+            filters["last_name__icontains"] = filter_volunteer_data.last_name
+        if filter_volunteer_data.email:
+            filters["email__iexact"] = filter_volunteer_data.email
+        if filter_volunteer_data.is_active is not None:
+            filters["is_active"] = filter_volunteer_data.is_active
+        if filter_volunteer_data.gender:
+            filters["gender__icontains"] = filter_volunteer_data.gender
+
+        return volunteer_dao.filter_all_volunteers(filtersDict=filters)
 
     def get_all_opportunities_of_a_volunteer(
         volunteer_id: int,

--- a/townhall/myapi/services.py
+++ b/townhall/myapi/services.py
@@ -103,18 +103,31 @@ class VolunteerServices:
         else:
             return volunteer_dao.get_volunteers_all()
 
-    def get_all_opportunities_of_a_volunteer(
-        volunteer_id: int,
+    def get_all_filtered_opportunities_of_a_volunteer(
+        filtered_opportunity_data: FilteredOpportunityData,
     ) -> QuerySet[Opportunity]:
-        try:
-            opportunities = volunteer_dao.get_all_opportunities_of_a_volunteer(
-                volunteer_id=volunteer_id
-            )
-            return opportunities
-        except Volunteer.DoesNotExist:
-            raise ValidationError(
-                f"Volunteer with the given id: {volunteer_id}, does not exist."
-            )
+        filters = {}
+
+        if filtered_opportunity_data.title:
+            filters["title__icontains"] = filtered_opportunity_data.title
+        if filtered_opportunity_data.starting_start_time:
+            filters["start_time__gte"] = filtered_opportunity_data.starting_start_time
+        if filtered_opportunity_data.starting_end_time:
+            filters["start_time__lte"] = filtered_opportunity_data.starting_end_time
+        if filtered_opportunity_data.ending_start_time:
+            filters["end_time__gte"] = filtered_opportunity_data.ending_start_time
+        if filtered_opportunity_data.ending_end_time:
+            filters["end_time__lte"] = filtered_opportunity_data.ending_end_time
+        if filtered_opportunity_data.location:
+            filters["location__icontains"] = filtered_opportunity_data.location
+        if filtered_opportunity_data.organization_id:
+            filters["organization_id"] = filtered_opportunity_data.organization_id
+        if filtered_opportunity_data.volunteer_id:
+            filters["volunteers__id"] = filtered_opportunity_data.volunteer_id
+
+        return volunteer_dao.get_all_filtered_opportunities_of_a_volunteer(
+            filters_dict=filters
+        )
 
     def add_volunteer_to_opportunity(volunteer_id: int, opportunity_id: int) -> None:
         try:

--- a/townhall/myapi/services.py
+++ b/townhall/myapi/services.py
@@ -46,9 +46,6 @@ logger = logging.getLogger(__name__)
 
 
 class VolunteerServices:
-    def get_volunteers_all() -> typing.List[Volunteer]:
-        return volunteer_dao.get_volunteers_all()
-
     def get_volunteer(id: int) -> typing.Optional[Volunteer]:
         try:
             volunteer = volunteer_dao.get_volunteer(id=id)
@@ -85,23 +82,26 @@ class VolunteerServices:
         except Volunteer.DoesNotExist:
             raise ValidationError(f"Volunteer with the given id: {id}, does not exist.")
 
-    def filter_all_volunteers(
-        filter_volunteer_data: FilterVolunteerData,
+    def get_all_volunteers_optional_filter(
+        filter_volunteer_data: typing.Optional[FilterVolunteerData] = None,
     ) -> QuerySet[Volunteer]:
-        filters = {}
+        if filter_volunteer_data is not None:
+            filters = {}
 
-        if filter_volunteer_data.first_name:
-            filters["first_name__icontains"] = filter_volunteer_data.first_name
-        if filter_volunteer_data.last_name:
-            filters["last_name__icontains"] = filter_volunteer_data.last_name
-        if filter_volunteer_data.email:
-            filters["email__iexact"] = filter_volunteer_data.email
-        if filter_volunteer_data.is_active is not None:
-            filters["is_active"] = filter_volunteer_data.is_active
-        if filter_volunteer_data.gender:
-            filters["gender__icontains"] = filter_volunteer_data.gender
+            if filter_volunteer_data.first_name:
+                filters["first_name__icontains"] = filter_volunteer_data.first_name
+            if filter_volunteer_data.last_name:
+                filters["last_name__icontains"] = filter_volunteer_data.last_name
+            if filter_volunteer_data.email:
+                filters["email__iexact"] = filter_volunteer_data.email
+            if filter_volunteer_data.is_active is not None:
+                filters["is_active"] = filter_volunteer_data.is_active
+            if filter_volunteer_data.gender:
+                filters["gender__icontains"] = filter_volunteer_data.gender
 
-        return volunteer_dao.filter_all_volunteers(filtersDict=filters)
+            return volunteer_dao.filter_all_volunteers(filtersDict=filters)
+        else:
+            return volunteer_dao.get_volunteers_all()
 
     def get_all_opportunities_of_a_volunteer(
         volunteer_id: int,

--- a/townhall/myapi/types.py
+++ b/townhall/myapi/types.py
@@ -23,6 +23,15 @@ class UpdateVolunteerData:
 
 
 @dataclass
+class FilterVolunteerData:
+    first_name: Optional[str] = None
+    last_name: Optional[str] = None
+    gender: Optional[str] = None
+    email: Optional[str] = None
+    is_active: Optional[bool] = None
+
+
+@dataclass
 class ChangeVolunteerPasswordData:
     id: int
     email: str

--- a/townhall/myapi/types.py
+++ b/townhall/myapi/types.py
@@ -69,6 +69,7 @@ class FilteredOpportunityData:
     ending_end_time: Optional[datetime] = None
     location: Optional[str] = None
     organization_id: Optional[int] = None
+    volunteer_id: Optional[int] = None
 
 
 @dataclass

--- a/townhall/myapi/views.py
+++ b/townhall/myapi/views.py
@@ -137,8 +137,37 @@ class VolunteerViewSet(viewsets.ModelViewSet):
 
     # GET All Volunteers
     @action(detail=False, methods=["get"], url_path="volunteer")
-    def get_all_volunteers_request(self, request):
-        volunteers = volunteer_services.get_volunteers_all()
+    def get_all_volunteers_optional_filter_request(self, request):
+        # Transforms requests JSON data into a python dictionary
+        serializer = FilterVolunteerSerializer(data=request.query_params)
+
+        # If the data is NOT valid return with a message serializers errors
+        if not serializer.is_valid():
+            return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
+
+        # If data is valid, Take out the validated data
+        validated_data = serializer.validated_data
+
+        # Get Should Filter value
+        should_filter = validated_data["should_filter"]
+
+        # If should filter, then create proceed with filter, otherwise do not
+        volunteers = None
+        if should_filter:
+            # Convert the validated data into the CreateVolunteerData type
+            filter_volunteer_data = FilterVolunteerData(
+                first_name=validated_data.get("first_name", None),
+                last_name=validated_data.get("last_name", None),
+                email=validated_data.get("email", None),
+                gender=validated_data.get("gender", None),
+                is_active=validated_data.get("is_active", None),
+            )
+
+            volunteers = volunteer_services.get_all_volunteers_optional_filter(
+                filter_volunteer_data
+            )
+        else:
+            volunteers = volunteer_services.get_all_volunteers_optional_filter(None)
 
         # If no volunteers exist, return an empty list
         if not volunteers:
@@ -152,49 +181,6 @@ class VolunteerViewSet(viewsets.ModelViewSet):
         return Response(
             {
                 "message": "All Volunteers retreived successfully",
-                "data": response_serializer.data,
-            },
-            status=status.HTTP_200_OK,
-        )
-
-    # GET All Filtered Volunteers
-    @action(detail=False, methods=["get"], url_path="filter")
-    def get_all_filtered_volunteers_request(self, request):
-        # Transforms requests JSON data into a python dictionary
-        serializer = FilterVolunteerSerializer(data=request.data)
-
-        # If the data is NOT valid return with a message serializers errors
-        if not serializer.is_valid():
-            return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
-
-        # If data is valid, Take out the validated data
-        validated_data = serializer.validated_data
-
-        # Convert the validated data into the CreateVolunteerData type
-        filter_volunteer_data = FilterVolunteerData(
-            first_name=validated_data.get("first_name", None),
-            last_name=validated_data.get("last_name", None),
-            email=validated_data.get("email", None),
-            gender=validated_data.get("gender", None),
-            is_active=validated_data.get("is_active", None),
-        )
-
-        filtered_volunteers = volunteer_services.filter_all_volunteers(
-            filter_volunteer_data
-        )
-
-        # If no volunteers exist, return an empty list
-        if not filtered_volunteers:
-            return Response(
-                {"message": "No Volunteers were found with those filters"},
-                status=status.HTTP_204_NO_CONTENT,
-            )
-
-        # Create the response serializer for the list of filtered volunteers
-        response_serializer = VolunteerSerializer(filtered_volunteers, many=True)
-        return Response(
-            {
-                "message": "All Volunteers with those filters retreived successfully",
                 "data": response_serializer.data,
             },
             status=status.HTTP_200_OK,

--- a/townhall/tests/endpoint_tests/test_volunteer_endpoint.py
+++ b/townhall/tests/endpoint_tests/test_volunteer_endpoint.py
@@ -169,7 +169,7 @@ class TestEndpointVolunteer(TestCase):
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(response.data["message"], "No Volunteers were found")
 
-    def test_get_all_opportunities_of_a_volunteer_success(self):
+    def test_get_all_filtered_opportunities_of_a_volunteer_no_filters(self):
         # Arrange
         organization = townhall_models.Organization.objects.create(
             id=1,
@@ -200,47 +200,140 @@ class TestEndpointVolunteer(TestCase):
         opportunity1.volunteers.add(townhall_models.Volunteer.objects.get(id=10))
         opportunity2.volunteers.add(townhall_models.Volunteer.objects.get(id=10))
         self.url = "/volunteer/10/opportunity/"
+        filter_data = {}
 
         # Act
-        response = self.client.get(self.url, format="json")
+        response = self.client.get(self.url, filter_data, format="json")
 
         # Assert
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(
             response.data["message"],
-            "Opportunities of this Volunteer retreived successfully",
+            "Filtered Opportunities of this Volunteer retreived successfully",
         )
-        volunteers = response.data["data"]
-        self.assertEqual(len(volunteers), 2)
+        opportunities = response.data["data"]
+        self.assertEqual(len(opportunities), 2)
 
-    @patch("myapi.services.VolunteerServices.get_all_opportunities_of_a_volunteer")
-    def test_get_all_opportunities_of_a_volunteer_success_none(
-        self, mock_get_all_opportunities_of_a_volunteer
+    def test_get_all_filtered_opportunities_of_a_volunteer_one_filter(self):
+        # Arrange
+        organization = townhall_models.Organization.objects.create(
+            id=1,
+            name="Sample Organization",
+            location="Sample Location",
+            email="Sample Email",
+            phone_number="Sample Phone Number",
+            website="Sample Website",
+        )
+        opportunity1 = townhall_models.Opportunity.objects.create(
+            id=1,
+            title="Sample Opportunity1",
+            start_time=timezone.make_aware(datetime(2024, 7, 20, 10, 0)),
+            end_time=timezone.make_aware(datetime(2024, 7, 20, 10, 0)),
+            description="Sample description",
+            location="Sample location",
+            organization=organization,
+        )
+        opportunity2 = townhall_models.Opportunity.objects.create(
+            id=2,
+            title="Sample Opportunity2",
+            start_time=timezone.make_aware(datetime(2024, 7, 20, 10, 0)),
+            end_time=timezone.make_aware(datetime(2024, 7, 20, 10, 0)),
+            description="Sample description",
+            location="Sample location",
+            organization=organization,
+        )
+        opportunity1.volunteers.add(townhall_models.Volunteer.objects.get(id=10))
+        opportunity2.volunteers.add(townhall_models.Volunteer.objects.get(id=10))
+        self.url = "/volunteer/10/opportunity/"
+        filter_data = {
+            "organization_id": 1,
+        }
+
+        # Act
+        response = self.client.get(self.url, filter_data, format="json")
+
+        # Assert
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(
+            response.data["message"],
+            "Filtered Opportunities of this Volunteer retreived successfully",
+        )
+        opportunities = response.data["data"]
+        self.assertEqual(len(opportunities), 2)
+
+    def test_get_all_filtered_opportunities_of_a_volunteer_all_filters(self):
+        # Arrange
+        organization = townhall_models.Organization.objects.create(
+            id=1,
+            name="Sample Organization",
+            location="Sample Location",
+            email="Sample Email",
+            phone_number="Sample Phone Number",
+            website="Sample Website",
+        )
+        opportunity1 = townhall_models.Opportunity.objects.create(
+            id=1,
+            title="Sample Opportunity1",
+            start_time=timezone.make_aware(datetime(2024, 7, 20, 10, 0)),
+            end_time=timezone.make_aware(datetime(2024, 7, 20, 10, 0)),
+            description="Sample description",
+            location="Sample location",
+            organization=organization,
+        )
+        opportunity2 = townhall_models.Opportunity.objects.create(
+            id=2,
+            title="Sample Opportunity2",
+            start_time=timezone.make_aware(datetime(2024, 7, 20, 10, 0)),
+            end_time=timezone.make_aware(datetime(2024, 7, 20, 10, 0)),
+            description="Sample description",
+            location="Sample location",
+            organization=organization,
+        )
+        opportunity1.volunteers.add(townhall_models.Volunteer.objects.get(id=10))
+        opportunity2.volunteers.add(townhall_models.Volunteer.objects.get(id=10))
+        self.url = "/volunteer/10/opportunity/"
+        filter_data = {
+            "title": "nity2",
+            "starting_start_time": "2024-07-19T21:45:00Z",
+            "starting_end_time": "2024-07-21T21:45:00Z",
+            "ending_start_time": "2024-07-19T21:45:00Z",
+            "ending_end_time": "2024-07-21T21:45:00Z",
+            "location": "le loca",
+            "organization_id": 1,
+        }
+
+        # Act
+        response = self.client.get(self.url, filter_data, format="json")
+
+        # Assert
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(
+            response.data["message"],
+            "Filtered Opportunities of this Volunteer retreived successfully",
+        )
+        opportunities = response.data["data"]
+        self.assertEqual(len(opportunities), 1)
+
+    @patch(
+        "myapi.services.VolunteerServices.get_all_filtered_opportunities_of_a_volunteer"
+    )
+    def test_get_all_filtered_opportunities_of_a_volunteer_success_none(
+        self, mock_get_all_filtered_opportunities_of_a_volunteer
     ):
         # Arrange
         empty_queryset = townhall_models.Opportunity.objects.none()
-        mock_get_all_opportunities_of_a_volunteer.return_value = empty_queryset
-        self.url = "/volunteer/11/opportunity/"
+        mock_get_all_filtered_opportunities_of_a_volunteer.return_value = empty_queryset
+        self.url = "/volunteer/999/opportunity/"
+        filter_data = {"location": "Vancou"}
 
         # Act
-        response = self.client.get(self.url, format="json")
+        response = self.client.get(self.url, filter_data, format="json")
 
         # Assert
         self.assertEqual(response.status_code, status.HTTP_200_OK)
-        self.assertEqual(response.data["message"], "No Opportunities were found")
-
-    def test_get_all_opportunities_of_a_volunteer_fail_service_error(self):
-        # Arrange
-        self.url = "/volunteer/999/opportunity/"
-
-        # Act
-        response = self.client.get(self.url, format="json")
-
-        # Assert
-        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
         self.assertEqual(
             response.data["message"],
-            "['Volunteer with the given id: 999, does not exist.']",
+            "No Opportunities were found with the specified filters",
         )
 
     def test_create_volunteer_success(self):

--- a/townhall/tests/service_tests/test_volunteer_service.py
+++ b/townhall/tests/service_tests/test_volunteer_service.py
@@ -9,7 +9,9 @@ from django.contrib.auth.hashers import check_password, make_password
 from myapi import models as townhall_models
 from myapi import services as townhall_services
 
-from myapi.types import CreateVolunteerData, UpdateVolunteerData
+from myapi.types import CreateVolunteerData
+from myapi.types import UpdateVolunteerData
+from myapi.types import FilterVolunteerData
 from myapi.types import ChangeVolunteerPasswordData
 
 
@@ -371,6 +373,71 @@ class TestVolunteerModel(TestCase):
             str(context.exception)
             == f"['Volunteer with the given id: {volunteer_id}, does not exist.']"
         )
+
+    def test_all_filters_volunteers_success_found(self):
+        # Arrange
+        filter_volunteer_data = FilterVolunteerData(
+            first_name="amor",
+            last_name="Re",
+            email="zamorak.red@gmail.com",
+            gender="M",
+            is_active=True,
+        )
+
+        # Act
+        volunteers = townhall_services.VolunteerServices.filter_all_volunteers(
+            filter_volunteer_data
+        )
+
+        # Assert
+        assert len(volunteers) == 1
+        ids = [volunteer.id for volunteer in volunteers]
+        assert set(ids) == {1}
+
+    def test_one_filter_volunters_success_many_found(self):
+        # Arrange
+        filter_volunteer_data = FilterVolunteerData(is_active=True)
+
+        # Act
+        volunteers = townhall_services.VolunteerServices.filter_all_volunteers(
+            filter_volunteer_data
+        )
+
+        # Assert
+        assert len(volunteers) == 2
+        ids = [volunteer.id for volunteer in volunteers]
+        assert set(ids) == {1, 2}
+
+    def test_all_filters_volunteers_success_not_found(self):
+        # Arrange
+        filter_volunteer_data = FilterVolunteerData(
+            first_name="amor",
+            last_name="Re",
+            email="zamorak.red@gmail.co",
+            gender="M",
+            is_active=True,
+        )
+
+        # Act
+        volunteers = townhall_services.VolunteerServices.filter_all_volunteers(
+            filter_volunteer_data
+        )
+
+        # Assert
+        assert len(volunteers) == 0
+
+    def test_one_filter_volunters_success_none_found(self):
+        # Arrange
+        filter_volunteer_data = FilterVolunteerData(is_active=False)
+
+        # Act
+        volunteers = townhall_services.VolunteerServices.filter_all_volunteers(
+            filter_volunteer_data
+        )
+
+        # Assert
+        print(volunteers)
+        assert len(volunteers) == 0
 
     @patch("myapi.services.VolunteerServices.authenticate_volunteer")
     @patch("myapi.services.VolunteerServices.validate_volunteer")

--- a/townhall/tests/service_tests/test_volunteer_service.py
+++ b/townhall/tests/service_tests/test_volunteer_service.py
@@ -27,15 +27,6 @@ class TestVolunteerModel(TestCase):
         call_command("loaddata", "volunteer_fixture.json")
         call_command("loaddata", "opportunity_fixture.json")
 
-    def test_get_all_volunteers(self):
-        # Act
-        volunteers = townhall_services.VolunteerServices.get_volunteers_all()
-
-        # Assert
-        assert len(volunteers) == 2
-        ids = [volunteer.id for volunteer in volunteers]
-        assert set(ids) == {1, 2}
-
     def test_get_volunteer_found(self):
         # Act
         volunteer = townhall_services.VolunteerServices.get_volunteer(id=1)
@@ -374,7 +365,7 @@ class TestVolunteerModel(TestCase):
             == f"['Volunteer with the given id: {volunteer_id}, does not exist.']"
         )
 
-    def test_all_filters_volunteers_success_found(self):
+    def test_get_all_volunteers_all_filters_success_found(self):
         # Arrange
         filter_volunteer_data = FilterVolunteerData(
             first_name="amor",
@@ -385,8 +376,10 @@ class TestVolunteerModel(TestCase):
         )
 
         # Act
-        volunteers = townhall_services.VolunteerServices.filter_all_volunteers(
-            filter_volunteer_data
+        volunteers = (
+            townhall_services.VolunteerServices.get_all_volunteers_optional_filter(
+                filter_volunteer_data
+            )
         )
 
         # Assert
@@ -394,13 +387,15 @@ class TestVolunteerModel(TestCase):
         ids = [volunteer.id for volunteer in volunteers]
         assert set(ids) == {1}
 
-    def test_one_filter_volunters_success_many_found(self):
+    def test_get_all_volunteers_one_filter_success_found(self):
         # Arrange
         filter_volunteer_data = FilterVolunteerData(is_active=True)
 
         # Act
-        volunteers = townhall_services.VolunteerServices.filter_all_volunteers(
-            filter_volunteer_data
+        volunteers = (
+            townhall_services.VolunteerServices.get_all_volunteers_optional_filter(
+                filter_volunteer_data
+            )
         )
 
         # Assert
@@ -408,7 +403,7 @@ class TestVolunteerModel(TestCase):
         ids = [volunteer.id for volunteer in volunteers]
         assert set(ids) == {1, 2}
 
-    def test_all_filters_volunteers_success_not_found(self):
+    def test_get_all_volunteers_all_filters_success_not_found(self):
         # Arrange
         filter_volunteer_data = FilterVolunteerData(
             first_name="amor",
@@ -419,25 +414,39 @@ class TestVolunteerModel(TestCase):
         )
 
         # Act
-        volunteers = townhall_services.VolunteerServices.filter_all_volunteers(
-            filter_volunteer_data
+        volunteers = (
+            townhall_services.VolunteerServices.get_all_volunteers_optional_filter(
+                filter_volunteer_data
+            )
         )
 
         # Assert
         assert len(volunteers) == 0
 
-    def test_one_filter_volunters_success_none_found(self):
+    def test_get_all_volunteers_one_filter_success_not_found(self):
         # Arrange
         filter_volunteer_data = FilterVolunteerData(is_active=False)
 
         # Act
-        volunteers = townhall_services.VolunteerServices.filter_all_volunteers(
-            filter_volunteer_data
+        volunteers = (
+            townhall_services.VolunteerServices.get_all_volunteers_optional_filter(
+                filter_volunteer_data
+            )
         )
 
         # Assert
-        print(volunteers)
         assert len(volunteers) == 0
+
+    def test_get_all_volunteers_no_filters_success(self):
+        # Act
+        volunteers = (
+            townhall_services.VolunteerServices.get_all_volunteers_optional_filter(None)
+        )
+
+        # Assert
+        assert len(volunteers) == 2
+        ids = [volunteer.id for volunteer in volunteers]
+        assert set(ids) == {1, 2}
 
     @patch("myapi.services.VolunteerServices.authenticate_volunteer")
     @patch("myapi.services.VolunteerServices.validate_volunteer")

--- a/townhall/tests/service_tests/test_volunteer_service.py
+++ b/townhall/tests/service_tests/test_volunteer_service.py
@@ -6,13 +6,16 @@ from unittest.mock import patch
 from django.core.exceptions import ValidationError
 from django.contrib.auth.hashers import check_password, make_password
 
-from myapi import models as townhall_models
-from myapi import services as townhall_services
+from myapi.models import Volunteer as vol_mod
+from myapi.models import Opportunity as opp_mod
+from myapi.services import VolunteerServices as vol_serv
 
 from myapi.types import CreateVolunteerData
 from myapi.types import UpdateVolunteerData
 from myapi.types import FilterVolunteerData
 from myapi.types import ChangeVolunteerPasswordData
+
+from myapi.types import FilteredOpportunityData
 
 
 # VOLUNTEER
@@ -29,7 +32,7 @@ class TestVolunteerModel(TestCase):
 
     def test_get_volunteer_found(self):
         # Act
-        volunteer = townhall_services.VolunteerServices.get_volunteer(id=1)
+        volunteer = vol_serv.get_volunteer(id=1)
 
         # Assert
         assert volunteer.first_name == "Zamorak"
@@ -46,12 +49,12 @@ class TestVolunteerModel(TestCase):
     @patch("myapi.dao.VolunteerDao.get_volunteer")
     def test_get_volunteer_failed_not_found(self, mock_get_volunteer):
         # Arrange
-        mock_get_volunteer.side_effect = townhall_models.Volunteer.DoesNotExist
+        mock_get_volunteer.side_effect = vol_mod.DoesNotExist
         volunteer_id = 999  # Assuming this ID does not exist
 
         # Act & Assert
         with self.assertRaises(ValidationError) as context:
-            townhall_services.VolunteerServices.get_volunteer(volunteer_id)
+            vol_serv.get_volunteer(volunteer_id)
 
         # Assert
         assert (
@@ -59,17 +62,18 @@ class TestVolunteerModel(TestCase):
             == f"['Volunteer with the given id: {volunteer_id}, does not exist.']"
         )
 
-    def test_get_all_opportunities_of_volunteer_found(self):
+    def test_get_all_opportunities_of_volunteer_found_no_filters(self):
         # Arrange
-        opportunity1 = townhall_models.Opportunity.objects.get(id=1)
-        opportunity2 = townhall_models.Opportunity.objects.get(id=2)
-        volunteer = townhall_services.VolunteerServices.get_volunteer(id=1)
+        opportunity1 = opp_mod.objects.get(id=1)
+        opportunity2 = opp_mod.objects.get(id=2)
+        volunteer = vol_serv.get_volunteer(id=1)
         opportunity1.volunteers.add(volunteer)
         opportunity2.volunteers.add(volunteer)
+        filtered_opportunity_data = FilteredOpportunityData(volunteer_id=1)
 
         # Act
-        opportunities = (
-            townhall_services.VolunteerServices.get_all_opportunities_of_a_volunteer(1)
+        opportunities = vol_serv.get_all_filtered_opportunities_of_a_volunteer(
+            filtered_opportunity_data
         )
 
         # Assert
@@ -77,27 +81,72 @@ class TestVolunteerModel(TestCase):
         ids = [opportunity.id for opportunity in opportunities]
         assert set(ids) == {1, 2}
 
-    @patch("myapi.dao.VolunteerDao.get_all_opportunities_of_a_volunteer")
-    def test_get_all_opportunities_of_volunteer_not_found(
-        self, mock_get_all_opportunities_of_a_volunteer
-    ):
+    def test_get_all_opportunities_of_volunteer_found_one_filter(self):
         # Arrange
-        mock_get_all_opportunities_of_a_volunteer.side_effect = (
-            townhall_models.Volunteer.DoesNotExist
+        opportunity1 = opp_mod.objects.get(id=1)
+        opportunity2 = opp_mod.objects.get(id=2)
+        volunteer = vol_serv.get_volunteer(id=1)
+        opportunity1.volunteers.add(volunteer)
+        opportunity2.volunteers.add(volunteer)
+        filtered_opportunity_data = FilteredOpportunityData(
+            location="Van", volunteer_id=1
         )
-        volunteer_id = 999  # Assuming this ID does not exist
 
-        # Act & Assert
-        with self.assertRaises(ValidationError) as context:
-            townhall_services.VolunteerServices.get_all_opportunities_of_a_volunteer(
-                volunteer_id
-            )
+        # Act
+        opportunities = vol_serv.get_all_filtered_opportunities_of_a_volunteer(
+            filtered_opportunity_data
+        )
 
         # Assert
-        assert (
-            str(context.exception)
-            == f"['Volunteer with the given id: {volunteer_id}, does not exist.']"
+        assert len(opportunities) == 2
+        ids = [opportunity.id for opportunity in opportunities]
+        assert set(ids) == {1, 2}
+
+    def test_get_all_opportunities_of_volunteer_found_all_filters(self):
+        # Arrange
+        opportunity1 = opp_mod.objects.get(id=1)
+        opportunity2 = opp_mod.objects.get(id=2)
+        volunteer = vol_serv.get_volunteer(id=1)
+        opportunity1.volunteers.add(volunteer)
+        opportunity2.volunteers.add(volunteer)
+        filtered_opportunity_data = FilteredOpportunityData(
+            title="ygien",
+            starting_start_time="2024-07-19T10:00:00Z",
+            starting_end_time="2024-07-21T10:00:00Z",
+            ending_start_time="2024-07-19T21:45:00Z",
+            ending_end_time="2024-07-21T21:45:00Z",
+            location="Vancouver",
+            organization_id=1,
+            volunteer_id=1,
         )
+
+        # Act
+        opportunities = vol_serv.get_all_filtered_opportunities_of_a_volunteer(
+            filtered_opportunity_data
+        )
+
+        # Assert
+        assert len(opportunities) == 1
+        ids = [opportunity.id for opportunity in opportunities]
+        assert set(ids) == {2}
+
+    @patch("myapi.dao.VolunteerDao.get_all_filtered_opportunities_of_a_volunteer")
+    def test_get_all_opportunities_of_volunteer_not_found(
+        self, mock_get_all_filtered_opportunities_of_a_volunteer
+    ):
+        # Arrange
+        mock_get_all_filtered_opportunities_of_a_volunteer.return_value = (
+            opp_mod.objects.none()
+        )
+        filtered_opportunity_data = FilteredOpportunityData(volunteer_id=1)
+
+        # Act
+        opportunities = vol_serv.get_all_filtered_opportunities_of_a_volunteer(
+            filtered_opportunity_data
+        )
+
+        # Assert
+        assert len(opportunities) == 0
 
     @patch("myapi.services.VolunteerServices.validate_volunteer")
     def test_create_volunteer_validation_error(self, mock_validate_volunteer):
@@ -113,17 +162,17 @@ class TestVolunteerModel(TestCase):
 
         # Act & Assert
         with self.assertRaises(ValidationError) as context:
-            townhall_services.VolunteerServices.create_volunteer(create_volunteer_data)
+            vol_serv.create_volunteer(create_volunteer_data)
 
         # Assert
         assert str(context.exception) == "['Random Error Message']"
 
     def test_add_volunteer_to_opportunity_success(self):
         # Act
-        townhall_services.VolunteerServices.add_volunteer_to_opportunity(1, 1)
+        vol_serv.add_volunteer_to_opportunity(1, 1)
 
         # Assert
-        volunteer = townhall_services.VolunteerServices.get_volunteer(id=1)
+        volunteer = vol_serv.get_volunteer(id=1)
         assert len(volunteer.opportunities.all()) == 1
         ids = [opportunity.id for opportunity in volunteer.opportunities.all()]
         assert set(ids) == {1}
@@ -133,16 +182,12 @@ class TestVolunteerModel(TestCase):
         self, mock_add_volunteer_to_opportunity
     ):
         # Arrange
-        mock_add_volunteer_to_opportunity.side_effect = (
-            townhall_models.Volunteer.DoesNotExist
-        )
+        mock_add_volunteer_to_opportunity.side_effect = vol_mod.DoesNotExist
         volunteer_id = 999  # Assuming this ID does not exist
 
         # Act & Assert
         with self.assertRaises(ValidationError) as context:
-            townhall_services.VolunteerServices.add_volunteer_to_opportunity(
-                volunteer_id, 1
-            )
+            vol_serv.add_volunteer_to_opportunity(volunteer_id, 1)
 
         # Assert
         assert (
@@ -155,16 +200,12 @@ class TestVolunteerModel(TestCase):
         self, mock_add_volunteer_to_opportunity
     ):
         # Arrange
-        mock_add_volunteer_to_opportunity.side_effect = (
-            townhall_models.Opportunity.DoesNotExist
-        )
+        mock_add_volunteer_to_opportunity.side_effect = opp_mod.DoesNotExist
         opportunity_id = 999  # Assuming this ID does not exist
 
         # Act & Assert
         with self.assertRaises(ValidationError) as context:
-            townhall_services.VolunteerServices.add_volunteer_to_opportunity(
-                1, opportunity_id
-            )
+            vol_serv.add_volunteer_to_opportunity(1, opportunity_id)
 
         # Assert
         assert (
@@ -174,17 +215,17 @@ class TestVolunteerModel(TestCase):
 
     def test_remove_volunteer_from_opportunity_success(self):
         # Arrange
-        opportunity1 = townhall_models.Opportunity.objects.get(id=1)
-        opportunity2 = townhall_models.Opportunity.objects.get(id=2)
-        volunteer = townhall_services.VolunteerServices.get_volunteer(id=1)
+        opportunity1 = opp_mod.objects.get(id=1)
+        opportunity2 = opp_mod.objects.get(id=2)
+        volunteer = vol_serv.get_volunteer(id=1)
         opportunity1.volunteers.add(volunteer)
         opportunity2.volunteers.add(volunteer)
 
         # Act
-        townhall_services.VolunteerServices.remove_volunteer_from_opportunity(1, 1)
+        vol_serv.remove_volunteer_from_opportunity(1, 1)
 
         # Assert
-        volunteer = townhall_services.VolunteerServices.get_volunteer(id=1)
+        volunteer = vol_serv.get_volunteer(id=1)
         assert len(volunteer.opportunities.all()) == 1
         ids = [opportunity.id for opportunity in volunteer.opportunities.all()]
         assert set(ids) == {2}
@@ -194,16 +235,12 @@ class TestVolunteerModel(TestCase):
         self, mock_remove_volunteer_from_opportunity
     ):
         # Arrange
-        mock_remove_volunteer_from_opportunity.side_effect = (
-            townhall_models.Volunteer.DoesNotExist
-        )
+        mock_remove_volunteer_from_opportunity.side_effect = vol_mod.DoesNotExist
         volunteer_id = 999  # Assuming this ID does not exist
 
         # Act & Assert
         with self.assertRaises(ValidationError) as context:
-            townhall_services.VolunteerServices.remove_volunteer_from_opportunity(
-                volunteer_id, 1
-            )
+            vol_serv.remove_volunteer_from_opportunity(volunteer_id, 1)
 
         # Assert
         assert (
@@ -216,16 +253,12 @@ class TestVolunteerModel(TestCase):
         self, mock_remove_volunteer_from_opportunity
     ):
         # Arrange
-        mock_remove_volunteer_from_opportunity.side_effect = (
-            townhall_models.Opportunity.DoesNotExist
-        )
+        mock_remove_volunteer_from_opportunity.side_effect = opp_mod.DoesNotExist
         opportunity_id = 999  # Assuming this ID does not exist
 
         # Act & Assert
         with self.assertRaises(ValidationError) as context:
-            townhall_services.VolunteerServices.add_volunteer_to_opportunity(
-                1, opportunity_id
-            )
+            vol_serv.add_volunteer_to_opportunity(1, opportunity_id)
 
         # Assert
         assert (
@@ -235,7 +268,7 @@ class TestVolunteerModel(TestCase):
 
     def test_update_volunteer_one_field_success(self):
         # Pre Assert
-        volunteer_before = townhall_services.VolunteerServices.get_volunteer(id=1)
+        volunteer_before = vol_serv.get_volunteer(id=1)
         assert volunteer_before.first_name == "Zamorak"
         assert volunteer_before.last_name == "Red"
         assert volunteer_before.email == "zamorak.red@gmail.com"
@@ -251,10 +284,10 @@ class TestVolunteerModel(TestCase):
         update_volunteer_data = UpdateVolunteerData(id=1, first_name="John")
 
         # Act
-        townhall_services.VolunteerServices.update_volunteer(update_volunteer_data)
+        vol_serv.update_volunteer(update_volunteer_data)
 
         # Assert
-        volunteer_after = townhall_models.Volunteer.objects.get(id=1)
+        volunteer_after = vol_mod.objects.get(id=1)
         assert volunteer_after.first_name == "John"
         assert volunteer_after.last_name == "Red"
         assert volunteer_after.email == "zamorak.red@gmail.com"
@@ -268,7 +301,7 @@ class TestVolunteerModel(TestCase):
 
     def test_update_volunteer_all_fields_success(self):
         # Pre Assert
-        volunteer_before = townhall_services.VolunteerServices.get_volunteer(id=1)
+        volunteer_before = vol_serv.get_volunteer(id=1)
         assert volunteer_before.first_name == "Zamorak"
         assert volunteer_before.last_name == "Red"
         assert volunteer_before.email == "zamorak.red@gmail.com"
@@ -291,10 +324,10 @@ class TestVolunteerModel(TestCase):
         )
 
         # Act
-        townhall_services.VolunteerServices.update_volunteer(update_volunteer_data)
+        vol_serv.update_volunteer(update_volunteer_data)
 
         # Assert
-        volunteer_after = townhall_models.Volunteer.objects.get(id=1)
+        volunteer_after = vol_mod.objects.get(id=1)
         assert volunteer_after.first_name == "John"
         assert volunteer_after.last_name == "Doe"
         assert volunteer_after.email == "john.doe@example.com"
@@ -309,14 +342,14 @@ class TestVolunteerModel(TestCase):
     @patch("myapi.dao.VolunteerDao.update_volunteer")
     def test_update_volunteer_failed_not_found(self, mock_update_volunteer):
         # Arrange
-        mock_update_volunteer.side_effect = townhall_models.Volunteer.DoesNotExist
+        mock_update_volunteer.side_effect = vol_mod.DoesNotExist
         update_volunteer_data = UpdateVolunteerData(
             id=999, first_name="John"  # Assuming this ID does not exist
         )
 
         # Act & Assert
         with self.assertRaises(ValidationError) as context:
-            townhall_services.VolunteerServices.update_volunteer(update_volunteer_data)
+            vol_serv.update_volunteer(update_volunteer_data)
 
         # Assert
         id = update_volunteer_data.id
@@ -327,7 +360,7 @@ class TestVolunteerModel(TestCase):
 
     def test_delete_volunteer_success(self):
         # Pre Assert
-        volunteer_before = townhall_services.VolunteerServices.get_volunteer(id=1)
+        volunteer_before = vol_serv.get_volunteer(id=1)
         assert volunteer_before.first_name == "Zamorak"
         assert volunteer_before.last_name == "Red"
         assert volunteer_before.email == "zamorak.red@gmail.com"
@@ -343,21 +376,21 @@ class TestVolunteerModel(TestCase):
         volunteer_id = 1
 
         # Act
-        townhall_services.VolunteerServices.delete_volunteer(volunteer_id)
+        vol_serv.delete_volunteer(volunteer_id)
 
         # Assert
-        with self.assertRaises(townhall_models.Volunteer.DoesNotExist):
-            townhall_models.Volunteer.objects.get(id=1)
+        with self.assertRaises(vol_mod.DoesNotExist):
+            vol_mod.objects.get(id=1)
 
     @patch("myapi.dao.VolunteerDao.delete_volunteer")
     def test_delete_volunteer_failed_not_found(self, mock_delete_volunteer):
         # Arrange
-        mock_delete_volunteer.side_effect = townhall_models.Volunteer.DoesNotExist
+        mock_delete_volunteer.side_effect = vol_mod.DoesNotExist
         volunteer_id = 999  # Assuming this ID does not exist
 
         # Act & Assert
         with self.assertRaises(ValidationError) as context:
-            townhall_services.VolunteerServices.delete_volunteer(volunteer_id)
+            vol_serv.delete_volunteer(volunteer_id)
 
         # Assert
         assert (
@@ -376,11 +409,7 @@ class TestVolunteerModel(TestCase):
         )
 
         # Act
-        volunteers = (
-            townhall_services.VolunteerServices.get_all_volunteers_optional_filter(
-                filter_volunteer_data
-            )
-        )
+        volunteers = vol_serv.get_all_volunteers_optional_filter(filter_volunteer_data)
 
         # Assert
         assert len(volunteers) == 1
@@ -392,11 +421,7 @@ class TestVolunteerModel(TestCase):
         filter_volunteer_data = FilterVolunteerData(is_active=True)
 
         # Act
-        volunteers = (
-            townhall_services.VolunteerServices.get_all_volunteers_optional_filter(
-                filter_volunteer_data
-            )
-        )
+        volunteers = vol_serv.get_all_volunteers_optional_filter(filter_volunteer_data)
 
         # Assert
         assert len(volunteers) == 2
@@ -414,11 +439,7 @@ class TestVolunteerModel(TestCase):
         )
 
         # Act
-        volunteers = (
-            townhall_services.VolunteerServices.get_all_volunteers_optional_filter(
-                filter_volunteer_data
-            )
-        )
+        volunteers = vol_serv.get_all_volunteers_optional_filter(filter_volunteer_data)
 
         # Assert
         assert len(volunteers) == 0
@@ -428,20 +449,14 @@ class TestVolunteerModel(TestCase):
         filter_volunteer_data = FilterVolunteerData(is_active=False)
 
         # Act
-        volunteers = (
-            townhall_services.VolunteerServices.get_all_volunteers_optional_filter(
-                filter_volunteer_data
-            )
-        )
+        volunteers = vol_serv.get_all_volunteers_optional_filter(filter_volunteer_data)
 
         # Assert
         assert len(volunteers) == 0
 
     def test_get_all_volunteers_no_filters_success(self):
         # Act
-        volunteers = (
-            townhall_services.VolunteerServices.get_all_volunteers_optional_filter(None)
-        )
+        volunteers = vol_serv.get_all_volunteers_optional_filter(None)
 
         # Assert
         assert len(volunteers) == 2
@@ -455,7 +470,7 @@ class TestVolunteerModel(TestCase):
     ):
         # Pre Arrange
         # Creating a Volunteer without a fixture to know the password pre hash
-        townhall_models.Volunteer.objects.create(
+        vol_mod.objects.create(
             id=3,
             first_name="Bruce",
             last_name="Wayne",
@@ -465,7 +480,7 @@ class TestVolunteerModel(TestCase):
         )
 
         # Pre Assert
-        volunteer_before = townhall_services.VolunteerServices.get_volunteer(id=3)
+        volunteer_before = vol_serv.get_volunteer(id=3)
         assert volunteer_before.first_name == "Bruce"
         assert volunteer_before.last_name == "Wayne"
         assert volunteer_before.email == "batman@gmail.com"
@@ -480,18 +495,14 @@ class TestVolunteerModel(TestCase):
             new_password="BruceWayne00",
         )
         # Ensure that these two methods always succeed and don't cause an error
-        mock_authenticate_volunteer.return_value = (
-            townhall_services.VolunteerServices.get_volunteer(id=3)
-        )
+        mock_authenticate_volunteer.return_value = vol_serv.get_volunteer(id=3)
         mock_validate_volunteer.return_value = None
 
         # Act
-        townhall_services.VolunteerServices.change_volunteers_password(
-            changePasswordData
-        )
+        vol_serv.change_volunteers_password(changePasswordData)
 
         # Assert
-        volunteer_after = townhall_services.VolunteerServices.get_volunteer(id=3)
+        volunteer_after = vol_serv.get_volunteer(id=3)
         assert volunteer_after.first_name == "Bruce"
         assert volunteer_after.last_name == "Wayne"
         assert volunteer_after.email == "batman@gmail.com"
@@ -518,9 +529,7 @@ class TestVolunteerModel(TestCase):
 
         # Act & Assert
         with self.assertRaises(ValidationError) as context:
-            townhall_services.VolunteerServices.change_volunteers_password(
-                changePasswordData
-            )
+            vol_serv.change_volunteers_password(changePasswordData)
 
         # Assert
         assert (
@@ -534,9 +543,7 @@ class TestVolunteerModel(TestCase):
         self, mock_validate_volunteer, mock_authenticate_volunteer
     ):
         # Arrange
-        mock_authenticate_volunteer.return_value = (
-            townhall_services.VolunteerServices.get_volunteer(id=2)
-        )
+        mock_authenticate_volunteer.return_value = vol_serv.get_volunteer(id=2)
         mock_validate_volunteer.side_effect = ValidationError("Random Error Message")
 
         changePasswordData = (
@@ -550,9 +557,7 @@ class TestVolunteerModel(TestCase):
 
         # Act & Assert
         with self.assertRaises(ValidationError) as context:
-            townhall_services.VolunteerServices.change_volunteers_password(
-                changePasswordData
-            )
+            vol_serv.change_volunteers_password(changePasswordData)
 
         # Assert
         assert str(context.exception) == "['Random Error Message']"
@@ -560,7 +565,7 @@ class TestVolunteerModel(TestCase):
     def test_authenticate_volunteer_success(self):
         # Pre Arrange
         # Creating a Volunteer without a fixture to know the password pre hash
-        townhall_models.Volunteer.objects.create(
+        vol_mod.objects.create(
             id=3,
             first_name="Bruce",
             last_name="Wayne",
@@ -570,7 +575,7 @@ class TestVolunteerModel(TestCase):
         )
 
         # Pre Assert
-        volunteer_before = townhall_services.VolunteerServices.get_volunteer(id=3)
+        volunteer_before = vol_serv.get_volunteer(id=3)
         assert volunteer_before.first_name == "Bruce"
         assert volunteer_before.last_name == "Wayne"
         assert volunteer_before.email == "batman@gmail.com"
@@ -582,9 +587,7 @@ class TestVolunteerModel(TestCase):
         password = "ImBatman99"
 
         # Act
-        returned_volunteer = townhall_services.VolunteerServices.authenticate_volunteer(
-            email, password
-        )
+        returned_volunteer = vol_serv.authenticate_volunteer(email, password)
 
         # Assert
         assert returned_volunteer.first_name == "Bruce"
@@ -599,9 +602,7 @@ class TestVolunteerModel(TestCase):
         password = "something_wrong1234"
 
         # Act & Assert
-        volunteer = townhall_services.VolunteerServices.authenticate_volunteer(
-            email, password
-        )
+        volunteer = vol_serv.authenticate_volunteer(email, password)
 
         # Assert
         assert volunteer is None
@@ -609,7 +610,7 @@ class TestVolunteerModel(TestCase):
     def test_authenticate_volunteer_failed_inactive(self):
         # Pre Arrange
         # Creating a Volunteer without a fixture to know the password pre hash
-        townhall_models.Volunteer.objects.create(
+        vol_mod.objects.create(
             id=3,
             first_name="Bruce",
             last_name="Wayne",
@@ -620,7 +621,7 @@ class TestVolunteerModel(TestCase):
         )
 
         # Pre Assert
-        volunteer_before = townhall_services.VolunteerServices.get_volunteer(id=3)
+        volunteer_before = vol_serv.get_volunteer(id=3)
         assert volunteer_before.first_name == "Bruce"
         assert volunteer_before.last_name == "Wayne"
         assert volunteer_before.email == "batman@gmail.com"
@@ -634,7 +635,7 @@ class TestVolunteerModel(TestCase):
 
         # Act & Assert
         with self.assertRaises(ValidationError) as context:
-            townhall_services.VolunteerServices.authenticate_volunteer(email, password)
+            vol_serv.authenticate_volunteer(email, password)
 
         # Assert
         assert str(context.exception) == "['Account is inactive.']"
@@ -646,9 +647,7 @@ class TestVolunteerModel(TestCase):
 
         # Act & Assert
         try:
-            townhall_services.VolunteerServices.validate_volunteer(
-                valid_email, valid_password
-            )
+            vol_serv.validate_volunteer(valid_email, valid_password)
         except ValidationError:
             self.fail("ValidationError raised incorrectly")
 
@@ -659,9 +658,7 @@ class TestVolunteerModel(TestCase):
 
         # Act & Assert
         with self.assertRaises(ValidationError) as context:
-            townhall_services.VolunteerServices.validate_volunteer(
-                invalid_email, valid_password
-            )
+            vol_serv.validate_volunteer(invalid_email, valid_password)
 
         # Assert
         assert str(context.exception) == "['Invalid email format.']"
@@ -673,9 +670,7 @@ class TestVolunteerModel(TestCase):
 
         # Act & Assert
         with self.assertRaises(ValidationError) as context:
-            townhall_services.VolunteerServices.validate_volunteer(
-                valid_email, invalid_password
-            )
+            vol_serv.validate_volunteer(valid_email, invalid_password)
 
         # Assert
         assert str(context.exception) == "['Invalid password.']"
@@ -687,9 +682,7 @@ class TestVolunteerModel(TestCase):
 
         # Act & Assert
         with self.assertRaises(ValidationError) as context:
-            townhall_services.VolunteerServices.validate_volunteer(
-                invalid_email, invalid_password
-            )
+            vol_serv.validate_volunteer(invalid_email, invalid_password)
 
         # Assert
         assert str(context.exception) == "['Password is too similar to the email.']"

--- a/townhall/townhall/urls.py
+++ b/townhall/townhall/urls.py
@@ -31,16 +31,11 @@ urlpatterns = [
         "volunteer/",
         VolunteerViewSet.as_view(
             {
-                "get": "get_all_volunteers_request",
+                "get": "get_all_volunteers_optional_filter_request",
                 "post": "create_volunteer_request",
             }
         ),
         name="volunteer",
-    ),
-    path(
-        "volunteer/filter/",
-        VolunteerViewSet.as_view({"get": "get_all_filtered_volunteers_request"}),
-        name="filter_volunteers",
     ),
     path(
         "volunteer/<int:vol_id>/",

--- a/townhall/townhall/urls.py
+++ b/townhall/townhall/urls.py
@@ -52,7 +52,7 @@ urlpatterns = [
         "volunteer/<int:vol_id>/opportunity/",
         VolunteerViewSet.as_view(
             {
-                "get": "get_all_opportunities_of_a_volunteer_request",
+                "get": "get_all_filtered_opportunities_of_a_volunteer_request",
                 "post": "add_volunteer_to_opportunity_request",
                 "delete": "remove_opportunity_from_a_volunteer_request",
             }

--- a/townhall/townhall/urls.py
+++ b/townhall/townhall/urls.py
@@ -38,6 +38,11 @@ urlpatterns = [
         name="volunteer",
     ),
     path(
+        "volunteer/filter/",
+        VolunteerViewSet.as_view({"get": "get_all_filtered_volunteers_request"}),
+        name="filter_volunteers",
+    ),
+    path(
         "volunteer/<int:vol_id>/",
         VolunteerViewSet.as_view(
             {


### PR DESCRIPTION
## JIRA Ticket Link
- https://atriadev.atlassian.net/jira/software/projects/TOW/boards/1?atlOrigin=eyJpIjoiYzc2YzEwZGU3OTJmNDYyNjgzYWZmZDBhMWY2ZmEyMjkiLCJwIjoiSmlyYS1Ob3Rpb25EQnN5bi1JbnQifQ&selectedIssue=TOW-182

## Migrations Required?
NO :negative_squared_cross_mark:

## Summary (a few sentences describing what this PR is doing) 
- This PR's main objective was to create endpoints to filter through all volunteers, and to filter through the endpoints of a volunteer. This PR does this, but does it as an extension to 2 existing endpoints whose functionalities were similar, get all volunteers was changed to allow for optional filtering, and get all opportunities of a volunteer was changed to allow for more filters on the list of opportunities rather than just volunteers.

## Checks
-  I have ran all the tests locally, and they all pass

## Impacted Areas in Application
- Areas about the volunteer model are all affected

## Learnings
- Doing this PR I learned alot, I learned alot more about the specifics regarding Djangos query system and how the ORM works behind the scenes. I also got a lot of good practice with creating new functionality by extending existing code.

NOTE: Due to an issue with max line length with Flake8 and auto formatting with Black. I ran into an issue where black would change the format of the the file such that the line was too long and Flake8 would fail, then you'd change the line length with ways that Black doesn't like and would fail, causing a loop of one or the other failing. As such I had to change the names of a few imports in one of the test files to deal with the issue
