### PR TITLE
Tow 103 create DAO and service method to GET Community

### DIFF
--- a/townhall/myapi/dao.py
+++ b/townhall/myapi/dao.py
@@ -3,6 +3,7 @@ from .models import Opportunity
 from .models import Organization
 from .models import Task
 from .models import Chat
+from .models import Community
 from .models import Project
 
 from .types import CreateVolunteerData
@@ -376,6 +377,17 @@ class ChatDao:
             chat.delete()  # Deletes the chat from the database
         except Chat.DoesNotExist:
             raise ValueError(f"Chat with ID {chat_id} does not exist.")
+
+
+class CommunityDao:
+
+    @staticmethod
+    def get_community(id: int) -> typing.Optional[Community]:
+        try:
+            community = Community.objects.get(id=id)
+            return community
+        except Community.DoesNotExist:
+            return None
 
 
 class ProjectDao:

--- a/townhall/myapi/services.py
+++ b/townhall/myapi/services.py
@@ -16,6 +16,7 @@ from .dao import OpportunityDao as opportunity_dao
 from .dao import OrganizationDao as organization_dao
 from .dao import TaskDao as task_dao
 from .dao import ChatDao as chat_dao
+from .dao import CommunityDao as community_dao
 from .dao import ProjectDao as project_dao
 
 from .types import CreateVolunteerData
@@ -37,6 +38,7 @@ from .models import Volunteer
 from .models import Opportunity
 from .models import Organization
 from .models import Task
+from .models import Community
 from .models import Project
 
 User = get_user_model()
@@ -441,6 +443,13 @@ class chatServices:
             return {"error": str(ve)}
         except Exception as e:
             return {"error": "An unexpected error occurred.", "details": str(e)}
+
+
+class CommunityServices:
+
+    @staticmethod
+    def get_community(id: int) -> typing.Optional[Community]:
+        return community_dao.get_community(id=id)
 
 
 class ProjectServices:

--- a/townhall/tests/service_tests/test_community_service.py
+++ b/townhall/tests/service_tests/test_community_service.py
@@ -1,0 +1,28 @@
+from django.test import TestCase
+from myapi import models as townhall_models
+from myapi import services as townhall_services
+
+# Community
+
+# Testing ALL tests "python manage.py test tests"
+# Testing ONLY community
+# python manage.py test tests.service_tests.test_community_service
+
+
+class TestCommunityModel(TestCase):
+    def setUp(self):
+        townhall_models.Community.objects.create(
+            id=1,
+            name="Community1",
+            description="Description1",
+        )
+
+    def test_get_community(self):
+        community = townhall_services.CommunityServices.get_community(id=1)
+        self.assertIsNotNone(community)
+        self.assertEqual(community.name, "Community1")
+        self.assertEqual(community.description, "Description1")
+
+    def test_get_community_not_found(self):
+        community = townhall_services.CommunityServices.get_community(id=100)
+        self.assertIsNone(community)


### PR DESCRIPTION
## JIRA Ticket Link
https://atriadev.atlassian.net/jira/software/projects/TOW/boards/1?assignee=712020%3Aa4ae0eae-1885-4172-a7b8-b78e96e4bec0&selectedIssue=TOW-103

## Migrations Required?
NO :negative_squared_cross_mark:

## Summary (a few sentences describing what this PR is doing)
This adds the dao and service code to GET a Community by ID
This PR is built off of TOW-105 which hasn't been merged yet

## Checks
-  [x] I have ran all the tests locally, and they all pass


## Related PRs
[https://github.com/AtriaCoop/townhallbackend/pull/86]

## Learnings
Describe in 1-2 sentences what you learned from doing this task
This had the same implementation as the other getters, but still good coding practice.
Learned from my previous mistake by basing this PR off of TOW-105 which it relies on.

