### PR TITLE
Tow 104 create DAO and service method to GET all Communities

### DIFF
--- a/townhall/myapi/dao.py
+++ b/townhall/myapi/dao.py
@@ -389,6 +389,10 @@ class CommunityDao:
         except Community.DoesNotExist:
             return None
 
+    @staticmethod
+    def get_community_all() -> QuerySet[Community]:
+        return Community.objects.all()
+
 
 class ProjectDao:
 

--- a/townhall/myapi/services.py
+++ b/townhall/myapi/services.py
@@ -451,6 +451,10 @@ class CommunityServices:
     def get_community(id: int) -> typing.Optional[Community]:
         return community_dao.get_community(id=id)
 
+    @staticmethod
+    def get_all_communities() -> typing.List[Community]:
+        return list(community_dao.get_community_all())
+
 
 class ProjectServices:
 

--- a/townhall/tests/service_tests/test_community_service.py
+++ b/townhall/tests/service_tests/test_community_service.py
@@ -16,6 +16,11 @@ class TestCommunityModel(TestCase):
             name="Community1",
             description="Description1",
         )
+        townhall_models.Community.objects.create(
+            id=2,
+            name="Community2",
+            description="Description2",
+        )
 
     def test_get_community(self):
         community = townhall_services.CommunityServices.get_community(id=1)
@@ -26,3 +31,11 @@ class TestCommunityModel(TestCase):
     def test_get_community_not_found(self):
         community = townhall_services.CommunityServices.get_community(id=100)
         self.assertIsNone(community)
+
+    def test_get_all_communities(self):
+        community = townhall_services.CommunityServices.get_all_communities()
+        self.assertEqual(len(community), 2)
+        self.assertEqual(community[0].name, "Community1")
+        self.assertEqual(community[0].description, "Description1")
+        self.assertEqual(community[1].name, "Community2")
+        self.assertEqual(community[1].description, "Description2")


### PR DESCRIPTION
## JIRA Ticket Link
[Tow 104](https://atriadev.atlassian.net/jira/software/projects/TOW/boards/1?assignee=712020%3Aa4ae0eae-1885-4172-a7b8-b78e96e4bec0&selectedIssue=TOW-104)

## Migrations Required?
NO :negative_squared_cross_mark:

## Summary (a few sentences describing what this PR is doing) 
Added DAO and service method to GET all Communities
Added 1 test

## Checks
-  [x] I have ran all the tests locally, and they all pass


## Related PRs
Tow 103 and Tow 105

## Learnings
Describe in 1-2 sentences what you learned from doing this task
I noticed that we aren't all consistent with our function naming

Examples are "get_volunteers_all", "get_opportunity_all", and "get_all_tasks".
The "all" is in different places + sometimes the noun gets pluralized and sometimes not

I chose to follow the third format and name it "get_all_opportunities"
